### PR TITLE
Fix for Y2038 gettimeofday for Win32 builds

### DIFF
--- a/apps/openssl/compat/poll_win.c
+++ b/apps/openssl/compat/poll_win.c
@@ -248,12 +248,12 @@ poll(struct pollfd *pfds, nfds_t nfds, int timeout_ms)
 	timespent_ms = 0;
 	wait_rc = WAIT_FAILED;
 
+	looptime_ms = (timeout_ms > 100 || timeout_ms == -1) ? 100 : timeout_ms;
 	if (timeout_ms < 0)
 		timeout_ms = INFINITE;
-	looptime_ms = timeout_ms > 100 ? 100 : timeout_ms;
 
 	do {
-		struct timeval tv;
+		TIMEVAL tv;
 		tv.tv_sec = 0;
 		tv.tv_usec = looptime_ms * 1000;
 		int handle_signaled = 0;

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -750,7 +750,7 @@ endif()
 
 if(WIN32)
 	set(CRYPTO_SRC ${CRYPTO_SRC} compat/posix_win.c)
-	set(EXTRA_EXPORT ${EXTRA_EXPORT} gettimeofday)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} gettimeofday=libressl_gettimeofday)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} getuid)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} posix_perror)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} posix_fopen)

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -9,6 +9,8 @@
 
 #define NO_REDEF_POSIX_FUNCTIONS
 
+#include <sys/time.h>
+
 #include <windows.h>
 #include <ws2tcpip.h>
 
@@ -303,7 +305,7 @@ int gettimeofday(struct timeval * tp, struct timezone * tzp)
 	time = ((uint64_t)file_time.dwLowDateTime);
 	time += ((uint64_t)file_time.dwHighDateTime) << 32;
 
-	tp->tv_sec = (long)((time - EPOCH) / 10000000L);
+	tp->tv_sec = (long long)((time - EPOCH) / 10000000L);
 	tp->tv_usec = (long)(system_time.wMilliseconds * 1000);
 	return 0;
 }

--- a/include/compat/sys/time.h
+++ b/include/compat/sys/time.h
@@ -14,7 +14,7 @@
 
 struct timeval {
     long long    tv_sec;
-	long         tv_usec;
+    long         tv_usec;
 };
 
 int gettimeofday(struct timeval *tp, void *tzp);

--- a/include/compat/sys/time.h
+++ b/include/compat/sys/time.h
@@ -8,6 +8,15 @@
 
 #ifdef _MSC_VER
 #include <winsock2.h>
+
+#define timeval libressl_timeval
+#define gettimeofday libressl_gettimeofday
+
+struct timeval {
+    long long    tv_sec;
+	long         tv_usec;
+};
+
 int gettimeofday(struct timeval *tp, void *tzp);
 #else
 #include_next <sys/time.h>


### PR DESCRIPTION
PR Summary
Fist part of the Y2038 issue on OpenSSH. Second part here: https://github.com/PowerShell/openssh-portable/pull/738
Porting LibreSSL fix (https://github.com/libressl/portable/pull/1078)  for gettimeofday on MSVC builds. 
timeval was taken from winsock2.h that is 32bit signed. 

PR Context
Besides overriding gettimeofday and timeval on MSVC platforms, we also need to modify the gettimeofday export of the dll with the overriden name openlss_gettimeofday on crypto/CMakeLists.txt.




